### PR TITLE
fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 The `unhcrpyplotstyle` package provides Matplotlib styles following [UNHCR Data Visualization Guidelines](https://www.unhcr.org/brand/wp-content/uploads/sites/89/2021/11/UNHCR_Data_Visualization_Guidelines.pdf) which ensures charts are professional and brand–compliant. The porpose of this package is to ease and speed up the chart creation process using Matplotlib custom stylesheets. 
 
 ## Getting started
-The easiest way to install `unhcrpyplostyle` package is by using `pip`:
+The easiest way to install `unhcrpyplotstyle` package is by using `pip`:
 
 ```bash
 # to install the lastest PyPI release


### PR DESCRIPTION
Thank you for the nice package!
I was wondering why pip could not install unhcrpyplotstyle and noticed a typo in the readme in the section "getting started". While the following code block is correct, the inline code is missing a "t" in "unhcrpyplostyle".
Since this is the second time I copied from the wrong line, others might trip over this, too.